### PR TITLE
Win8 without ads

### DIFF
--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
@@ -1,0 +1,89 @@
+﻿; Tested on Windows 8.1, 1920x1080, 100% Scale with no ads
+; Escape will exit the app
+
+UseColorCheck := false
+KeepRunning := false
+
+Escape:: ExitApp ; Escape to exit
+^p::Pause ; Ctrl+P Pause
+
+^b::      ; Ctrl+B AutoDaubt
+if KeepRunning  ; This means an underlying thread is already running the loop below.
+{
+    KeepRunning := false  ; Signal that thread's loop to stop.
+    return  ; End this thread so that the one underneath will resume and see the change made by the line above.
+}
+KeepRunning := true
+{
+	SpaceX := 76, SpaceY := 62
+
+	; First row
+	DaubtCard(780, 210, SpaceX, SpaceY)
+	DaubtCard(1200, 210, SpaceX, SpaceY)
+	
+	; Second row
+	DaubtCard(780, 680, SpaceX, SpaceY)
+	DaubtCard(1200, 680, SpaceX, SpaceY)
+
+	Return
+}
+
+DaubtCard(CardX, CardY, SpaceX, SpaceY) 
+{
+	X := CardX, Y := CardY
+
+	MouseMove, %X%, %Y%, 0
+
+	Loop, 5
+	{
+		DaubtColumn(X, Y, SpaceY, A_Index)
+
+		If (A_Index < 5) {
+			X += SpaceX
+			MouseMove, %X%, %Y%, 0
+		}
+		
+		if not KeepRunning  ; The user signaled the loop to stop by pressing Win-Z again.
+			break  ; Break out of this loop.
+	}
+}
+
+DaubtColumn(ColumnX, ColumnY, SpaceY, Column)
+{
+	Daubt(ColumnX, ColumnY)
+
+	Loop, 4
+	{
+		ColumnY += SpaceY
+		MouseMove, %ColumnX%, %ColumnY%, 0
+
+		If (!(Column = 3 and A_Index = 2))
+		{
+			Daubt(ColumnX, ColumnY)
+		}
+		
+		if not KeepRunning  ; The user signaled the loop to stop by pressing Win-Z again.
+			break  ; Break out of this loop.
+	}
+}
+
+Daubt(TileX, TileY)
+{
+	Global UseColorCheck
+
+	If (UseColorCheck = true) 
+	{
+		PixelGetColor, Color, %TileX%, %TileY%, RGB
+
+		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+
+		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		{
+			MouseClick, Left, %TileX%, %TileY%, 2, 0
+		}
+	}
+	Else
+	{
+		MouseClick, Left, %TileX%, %TileY%, 2, 0
+	}
+}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
@@ -8,15 +8,15 @@ Escape:: ExitApp ; Escape to exit
 
 ^b::      ; Ctrl+B AutoDaubt
 {
-	SpaceX := 76, SpaceY := 62
+	SpaceX := 75, SpaceY := 65
 
 	; First row
-	DaubtCard(780, 210, SpaceX, SpaceY)
-	DaubtCard(1200, 210, SpaceX, SpaceY)
+	DaubtCard(805, 210, SpaceX, SpaceY)
+	DaubtCard(1225, 210, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(780, 680, SpaceX, SpaceY)
-	DaubtCard(1200, 680, SpaceX, SpaceY)
+	DaubtCard(805, 680, SpaceX, SpaceY)
+	DaubtCard(1225, 680, SpaceX, SpaceY)
 
 	Return
 }

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
@@ -11,12 +11,12 @@ Escape:: ExitApp ; Escape to exit
 	SpaceX := 75, SpaceY := 65
 
 	; First row
-	DaubtCard(805, 210, SpaceX, SpaceY)
-	DaubtCard(1225, 210, SpaceX, SpaceY)
+	DaubtCard(805, 225, SpaceX, SpaceY)
+	DaubtCard(1225, 225, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(805, 680, SpaceX, SpaceY)
-	DaubtCard(1225, 680, SpaceX, SpaceY)
+	DaubtCard(805, 700, SpaceX, SpaceY)
+	DaubtCard(1225, 700, SpaceX, SpaceY)
 
 	Return
 }
@@ -62,9 +62,13 @@ Daubt(TileX, TileY)
 	{
 		PixelGetColor, Color, %TileX%, %TileY%, RGB
 
-		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
+		
+		IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		If (!IsRed and !IsGreen and !IsWhite)
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
@@ -6,6 +6,26 @@ UseColorCheck := true
 Escape:: ExitApp ; Escape to exit
 ^p::Pause ; Ctrl+P Pause
 
+; Ctrl+O to click on the power up button
+^o::
+{
+	MouseClick, Left, 1845, 300, 1, 0
+	Return
+}
+
+; Ctrl+D to click on the Bingo buttons
+^d::
+{
+	; First Row
+	MouseClick, Left, 950, 560, 1, 0
+	MouseClick, Left, 1350, 560, 1, 0
+
+	; Second Row
+	MouseClick, Left, 950, 1030, 1, 0
+	MouseClick, Left, 1350, 1030, 1, 0
+	Return
+}
+
 ^b::      ; Ctrl+B AutoDaubt
 {
 	SpaceX := 75, SpaceY := 65
@@ -78,12 +98,3 @@ Daubt(TileX, TileY)
 		MouseClick, Left, %TileX%, %TileY%, 2, 0
 	}
 }
-
-^d::
-; First Row
-MouseClick, Left, 950, 560, 1, 0
-MouseClick, Left, 1350, 560, 1, 0
-
-; Second Row
-MouseClick, Left, 950, 1030, 1, 0
-MouseClick, Left, 1350, 1030, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.4-cards.ahk
@@ -84,11 +84,13 @@ Daubt(TileX, TileY)
 
 		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
 		
-		IsRed := (Red == "C" and Green == "2" and Blue == "0")
-		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
-		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
+		; IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		; IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		; IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!IsRed and !IsGreen and !IsWhite)
+		If (!(Red == "C" and Blue == "0") and	; If it is not Red
+			!(Red == "6" and Blue == "2") and	; and not Green
+			!(Red == "F" and Blue == "F"))		; and not White
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
@@ -8,17 +8,17 @@ Escape:: ExitApp ; Escape to exit
 
 ^b::      ; Ctrl+B AutoDaubt
 {
-	SpaceX := 76, SpaceY := 62
+	SpaceX := 70, SpaceY := 65
 
 	; First row
-	DaubtCard(625, 235, SpaceX, SpaceY)
-	DaubtCard(1025, 235, SpaceX, SpaceY)
-	DaubtCard(1400, 235, SpaceX, SpaceY)
+	DaubtCard(635, 235, SpaceX, SpaceY)
+	DaubtCard(1030, 235, SpaceX, SpaceY)
+	DaubtCard(1420, 235, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(625, 680, SpaceX, SpaceY)
-	DaubtCard(1025, 680, SpaceX, SpaceY)
-	DaubtCard(1400, 680, SpaceX, SpaceY)
+	DaubtCard(635, 680, SpaceX, SpaceY)
+	DaubtCard(1030, 680, SpaceX, SpaceY)
+	DaubtCard(1420, 680, SpaceX, SpaceY)
 
 	Return
 }

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
@@ -88,11 +88,13 @@ Daubt(TileX, TileY)
 
 		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
 		
-		IsRed := (Red == "C" and Green == "2" and Blue == "0")
-		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
-		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
+		; IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		; IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		; IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!IsRed and !IsGreen and !IsWhite)
+		If (!(Red == "C" and Blue == "0") and	; If it is not Red
+			!(Red == "6" and Blue == "2") and	; and not Green
+			!(Red == "F" and Blue == "F"))		; and not White
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
@@ -11,14 +11,14 @@ Escape:: ExitApp ; Escape to exit
 	SpaceX := 70, SpaceY := 65
 
 	; First row
-	DaubtCard(635, 235, SpaceX, SpaceY)
-	DaubtCard(1030, 235, SpaceX, SpaceY)
-	DaubtCard(1420, 235, SpaceX, SpaceY)
+	DaubtCard(630, 255, SpaceX, SpaceY)
+	DaubtCard(1025, 235, SpaceX, SpaceY)
+	DaubtCard(1415, 235, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(635, 680, SpaceX, SpaceY)
-	DaubtCard(1030, 680, SpaceX, SpaceY)
-	DaubtCard(1420, 680, SpaceX, SpaceY)
+	DaubtCard(630, 680, SpaceX, SpaceY)
+	DaubtCard(1025, 680, SpaceX, SpaceY)
+	DaubtCard(1415, 680, SpaceX, SpaceY)
 
 	Return
 }
@@ -64,9 +64,13 @@ Daubt(TileX, TileY)
 	{
 		PixelGetColor, Color, %TileX%, %TileY%, RGB
 
-		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
+		
+		IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		If (!IsRed and !IsGreen and !IsWhite)
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
@@ -6,6 +6,28 @@ UseColorCheck := true
 Escape:: ExitApp ; Escape to exit
 ^p::Pause ; Ctrl+P Pause
 
+; Ctrl+O to click on the power up button
+^o::
+{
+	MouseClick, Left, 1845, 300, 1, 0
+	Return
+}
+
+; Ctrl+D to click on the Bingo buttons
+^d::
+{
+	; First Row
+	MouseClick, Left, 775, 560, 1, 0
+	MouseClick, Left, 1150, 560, 1, 0
+	MouseClick, Left, 1550, 560, 1, 0
+
+	; Second Row
+	MouseClick, Left, 775, 1000, 1, 0
+	MouseClick, Left, 1150, 1000, 1, 0
+	MouseClick, Left, 1550, 1000, 1, 0
+	Return
+}
+
 ^b::      ; Ctrl+B AutoDaubt
 {
 	SpaceX := 70, SpaceY := 65
@@ -80,14 +102,3 @@ Daubt(TileX, TileY)
 		MouseClick, Left, %TileX%, %TileY%, 2, 0
 	}
 }
-
-^d::
-; First Row
-MouseClick, Left, 775, 560, 1, 0
-MouseClick, Left, 1150, 560, 1, 0
-MouseClick, Left, 1550, 560, 1, 0
-
-; Second Row
-MouseClick, Left, 775, 1000, 1, 0
-MouseClick, Left, 1150, 1000, 1, 0
-MouseClick, Left, 1550, 1000, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.6-cards.ahk
@@ -11,12 +11,14 @@ Escape:: ExitApp ; Escape to exit
 	SpaceX := 76, SpaceY := 62
 
 	; First row
-	DaubtCard(780, 210, SpaceX, SpaceY)
-	DaubtCard(1200, 210, SpaceX, SpaceY)
+	DaubtCard(625, 235, SpaceX, SpaceY)
+	DaubtCard(1025, 235, SpaceX, SpaceY)
+	DaubtCard(1400, 235, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(780, 680, SpaceX, SpaceY)
-	DaubtCard(1200, 680, SpaceX, SpaceY)
+	DaubtCard(625, 680, SpaceX, SpaceY)
+	DaubtCard(1025, 680, SpaceX, SpaceY)
+	DaubtCard(1400, 680, SpaceX, SpaceY)
 
 	Return
 }
@@ -77,9 +79,11 @@ Daubt(TileX, TileY)
 
 ^d::
 ; First Row
-MouseClick, Left, 950, 560, 1, 0
-MouseClick, Left, 1350, 560, 1, 0
+MouseClick, Left, 775, 560, 1, 0
+MouseClick, Left, 1150, 560, 1, 0
+MouseClick, Left, 1550, 560, 1, 0
 
 ; Second Row
-MouseClick, Left, 950, 1030, 1, 0
-MouseClick, Left, 1350, 1030, 1, 0
+MouseClick, Left, 775, 1000, 1, 0
+MouseClick, Left, 1150, 1000, 1, 0
+MouseClick, Left, 1550, 1000, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -1,6 +1,7 @@
 ﻿; Tested on Windows 8.1, 1920x1080, 100% Scale with no ads
 
-UseColorCheck := false
+; Check the color of the tile before clicking it twice, this is slower on empty boards, but will gain speed later on
+UseColorCheck := true
 
 Escape:: ExitApp ; Escape to exit
 ^p::Pause ; Ctrl+P Pause
@@ -79,3 +80,15 @@ Daubt(TileX, TileY)
 		MouseClick, Left, %TileX%, %TileY%, 2, 0
 	}
 }
+
+^d::
+MouseClick, Left, 880, 420, 1, 0
+MouseClick, Left, 1165, 420, 1, 0
+MouseClick, Left, 1445, 420, 1, 0
+
+MouseClick, Left, 880, 740, 1, 0
+MouseClick, Left, 1165, 740, 1, 0
+MouseClick, Left, 1445, 740, 1, 0
+
+MouseClick, Left, 880, 1050, 1, 0
+MouseClick, Left, 1165, 1050, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -6,6 +6,29 @@ UseColorCheck := true
 Escape:: ExitApp ; Escape to exit
 ^p::Pause ; Ctrl+P Pause
 
+; Ctrl+O to click on the power up button
+^o::
+{
+	MouseClick, Left, 1845, 300, 1, 0
+	Return
+}
+
+; Ctrl+D to click on the Bingo buttons
+^d::
+{
+	MouseClick, Left, 880, 420, 1, 0
+	MouseClick, Left, 1165, 420, 1, 0
+	MouseClick, Left, 1445, 420, 1, 0
+
+	MouseClick, Left, 880, 740, 1, 0
+	MouseClick, Left, 1165, 740, 1, 0
+	MouseClick, Left, 1445, 740, 1, 0
+
+	MouseClick, Left, 880, 1050, 1, 0
+	MouseClick, Left, 1165, 1050, 1, 0
+	Return
+}
+
 ^b::      ; Ctrl+B AutoDaubt
 {
 	SpaceX := 50, SpaceY := 41
@@ -85,15 +108,3 @@ Daubt(TileX, TileY)
 		MouseClick, Left, %TileX%, %TileY%, 2, 0
 	}
 }
-
-^d::
-MouseClick, Left, 880, 420, 1, 0
-MouseClick, Left, 1165, 420, 1, 0
-MouseClick, Left, 1445, 420, 1, 0
-
-MouseClick, Left, 880, 740, 1, 0
-MouseClick, Left, 1165, 740, 1, 0
-MouseClick, Left, 1445, 740, 1, 0
-
-MouseClick, Left, 880, 1050, 1, 0
-MouseClick, Left, 1165, 1050, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -94,11 +94,13 @@ Daubt(TileX, TileY)
 
 		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
 		
-		IsRed := (Red == "C" and Green == "2" and Blue == "0")
-		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
-		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
+		; IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		; IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		; IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!IsRed and !IsGreen and !IsWhite)
+		If (!(Red == "C" and Blue == "0") and	; If it is not Red
+			!(Red == "6" and Blue == "2") and	; and not Green
+			!(Red == "F" and Blue == "F"))		; and not White
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -10,19 +10,20 @@ Escape:: ExitApp ; Escape to exit
 {
 	SpaceX := 50, SpaceY := 41
 
+	; Coordinate seeds need to be in the center of the tile for ColorCheck to work correctly.
 	; First row
-	DaubtCard(785, 185, SpaceX, SpaceY)
-	DaubtCard(1065, 185, SpaceX, SpaceY)
-	DaubtCard(1345, 185, SpaceX, SpaceY)
+	DaubtCard(785, 195, SpaceX, SpaceY)
+	DaubtCard(1065, 195, SpaceX, SpaceY)
+	DaubtCard(1345, 195, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(785, 500, SpaceX, SpaceY)
-	DaubtCard(1065, 500, SpaceX, SpaceY)
-	DaubtCard(1345, 500, SpaceX, SpaceY)
+	DaubtCard(785, 510, SpaceX, SpaceY)
+	DaubtCard(1065, 510, SpaceX, SpaceY)
+	DaubtCard(1345, 510, SpaceX, SpaceY)
 	
 	; Third row
-	DaubtCard(785, 815, SpaceX, SpaceY)
-	DaubtCard(1065, 815, SpaceX, SpaceY)
+	DaubtCard(785, 825, SpaceX, SpaceY)
+	DaubtCard(1065, 825, SpaceX, SpaceY)
 
 	Return
 }
@@ -68,9 +69,13 @@ Daubt(TileX, TileY)
 	{
 		PixelGetColor, Color, %TileX%, %TileY%, RGB
 
-		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
+		
+		IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		If (!IsRed and !IsGreen and !IsWhite)
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -8,21 +8,21 @@ Escape:: ExitApp ; Escape to exit
 
 ^b::      ; Ctrl+B AutoDaubt
 {
-	SpaceX := 50, SpaceY := 40
+	SpaceX := 50, SpaceY := 41
 
 	; First row
-	DaubtCard(770, 185, SpaceX, SpaceY)
-	DaubtCard(1050, 185, SpaceX, SpaceY)
-	DaubtCard(1330, 185, SpaceX, SpaceY)
+	DaubtCard(785, 185, SpaceX, SpaceY)
+	DaubtCard(1065, 185, SpaceX, SpaceY)
+	DaubtCard(1345, 185, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(770, 500, SpaceX, SpaceY)
-	DaubtCard(1050, 500, SpaceX, SpaceY)
-	DaubtCard(1330, 500, SpaceX, SpaceY)
+	DaubtCard(785, 500, SpaceX, SpaceY)
+	DaubtCard(1065, 500, SpaceX, SpaceY)
+	DaubtCard(1345, 500, SpaceX, SpaceY)
 	
 	; Third row
-	DaubtCard(770, 815, SpaceX, SpaceY)
-	DaubtCard(1050, 815, SpaceX, SpaceY)
+	DaubtCard(785, 815, SpaceX, SpaceY)
+	DaubtCard(1065, 815, SpaceX, SpaceY)
 
 	Return
 }

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.8-cards.ahk
@@ -1,0 +1,81 @@
+﻿; Tested on Windows 8.1, 1920x1080, 100% Scale with no ads
+
+UseColorCheck := false
+
+Escape:: ExitApp ; Escape to exit
+^p::Pause ; Ctrl+P Pause
+
+^b::      ; Ctrl+B AutoDaubt
+{
+	SpaceX := 50, SpaceY := 40
+
+	; First row
+	DaubtCard(770, 185, SpaceX, SpaceY)
+	DaubtCard(1050, 185, SpaceX, SpaceY)
+	DaubtCard(1330, 185, SpaceX, SpaceY)
+	
+	; Second row
+	DaubtCard(770, 500, SpaceX, SpaceY)
+	DaubtCard(1050, 500, SpaceX, SpaceY)
+	DaubtCard(1330, 500, SpaceX, SpaceY)
+	
+	; Third row
+	DaubtCard(770, 815, SpaceX, SpaceY)
+	DaubtCard(1050, 815, SpaceX, SpaceY)
+
+	Return
+}
+
+DaubtCard(CardX, CardY, SpaceX, SpaceY) 
+{
+	X := CardX, Y := CardY
+
+	MouseMove, %X%, %Y%, 0
+
+	Loop, 5
+	{
+		DaubtColumn(X, Y, SpaceY, A_Index)
+
+		If (A_Index < 5) {
+			X += SpaceX
+			MouseMove, %X%, %Y%, 0
+		}
+	}
+}
+
+DaubtColumn(ColumnX, ColumnY, SpaceY, Column)
+{
+	Daubt(ColumnX, ColumnY)
+
+	Loop, 4
+	{
+		ColumnY += SpaceY
+		MouseMove, %ColumnX%, %ColumnY%, 0
+
+		If (!(Column = 3 and A_Index = 2))
+		{
+			Daubt(ColumnX, ColumnY)
+		}
+	}
+}
+
+Daubt(TileX, TileY)
+{
+	Global UseColorCheck
+
+	If (UseColorCheck = true) 
+	{
+		PixelGetColor, Color, %TileX%, %TileY%, RGB
+
+		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+
+		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		{
+			MouseClick, Left, %TileX%, %TileY%, 2, 0
+		}
+	}
+	Else
+	{
+		MouseClick, Left, %TileX%, %TileY%, 2, 0
+	}
+}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
@@ -8,15 +8,22 @@ Escape:: ExitApp ; Escape to exit
 
 ^b::      ; Ctrl+B AutoDaubt
 {
-	SpaceX := 76, SpaceY := 62
+	SpaceX := 50, SpaceY := 40
 
 	; First row
-	DaubtCard(780, 210, SpaceX, SpaceY)
-	DaubtCard(1200, 210, SpaceX, SpaceY)
+	DaubtCard(770, 185, SpaceX, SpaceY)
+	DaubtCard(1050, 185, SpaceX, SpaceY)
+	DaubtCard(1330, 185, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(780, 680, SpaceX, SpaceY)
-	DaubtCard(1200, 680, SpaceX, SpaceY)
+	DaubtCard(770, 500, SpaceX, SpaceY)
+	DaubtCard(1050, 500, SpaceX, SpaceY)
+	DaubtCard(1330, 500, SpaceX, SpaceY)
+	
+	; Third row
+	DaubtCard(770, 815, SpaceX, SpaceY)
+	DaubtCard(1050, 815, SpaceX, SpaceY)
+	DaubtCard(1330, 815, SpaceX, SpaceY)
 
 	Return
 }
@@ -76,10 +83,14 @@ Daubt(TileX, TileY)
 }
 
 ^d::
-; First Row
-MouseClick, Left, 950, 560, 1, 0
-MouseClick, Left, 1350, 560, 1, 0
+MouseClick, Left, 880, 420, 1, 0
+MouseClick, Left, 1165, 420, 1, 0
+MouseClick, Left, 1445, 420, 1, 0
 
-; Second Row
-MouseClick, Left, 950, 1030, 1, 0
-MouseClick, Left, 1350, 1030, 1, 0
+MouseClick, Left, 880, 740, 1, 0
+MouseClick, Left, 1165, 740, 1, 0
+MouseClick, Left, 1445, 740, 1, 0
+
+MouseClick, Left, 880, 1050, 1, 0
+MouseClick, Left, 1165, 1050, 1, 0
+MouseClick, Left, 1445, 1050, 1, 0

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
@@ -96,11 +96,13 @@ Daubt(TileX, TileY)
 
 		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
 		
-		IsRed := (Red == "C" and Green == "2" and Blue == "0")
-		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
-		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
+		; IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		; IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		; IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!IsRed and !IsGreen and !IsWhite)
+		If (!(Red == "C" and Blue == "0") and	; If it is not Red
+			!(Red == "6" and Blue == "2") and	; and not Green
+			!(Red == "F" and Blue == "F"))		; and not White
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
@@ -8,22 +8,22 @@ Escape:: ExitApp ; Escape to exit
 
 ^b::      ; Ctrl+B AutoDaubt
 {
-	SpaceX := 50, SpaceY := 40
+	SpaceX := 50, SpaceY := 41
 
 	; First row
-	DaubtCard(770, 185, SpaceX, SpaceY)
-	DaubtCard(1050, 185, SpaceX, SpaceY)
-	DaubtCard(1330, 185, SpaceX, SpaceY)
+	DaubtCard(785, 185, SpaceX, SpaceY)
+	DaubtCard(1065, 185, SpaceX, SpaceY)
+	DaubtCard(1345, 185, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(770, 500, SpaceX, SpaceY)
-	DaubtCard(1050, 500, SpaceX, SpaceY)
-	DaubtCard(1330, 500, SpaceX, SpaceY)
+	DaubtCard(785, 500, SpaceX, SpaceY)
+	DaubtCard(1065, 500, SpaceX, SpaceY)
+	DaubtCard(1345, 500, SpaceX, SpaceY)
 	
 	; Third row
-	DaubtCard(770, 815, SpaceX, SpaceY)
-	DaubtCard(1050, 815, SpaceX, SpaceY)
-	DaubtCard(1330, 815, SpaceX, SpaceY)
+	DaubtCard(785, 815, SpaceX, SpaceY)
+	DaubtCard(1065, 815, SpaceX, SpaceY)
+	DaubtCard(1345, 815, SpaceX, SpaceY)
 
 	Return
 }

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
@@ -10,20 +10,21 @@ Escape:: ExitApp ; Escape to exit
 {
 	SpaceX := 50, SpaceY := 41
 
+	; Coordinate seeds need to be in the center of the tile for ColorCheck to work correctly.
 	; First row
-	DaubtCard(785, 185, SpaceX, SpaceY)
-	DaubtCard(1065, 185, SpaceX, SpaceY)
-	DaubtCard(1345, 185, SpaceX, SpaceY)
+	DaubtCard(785, 195, SpaceX, SpaceY)
+	DaubtCard(1065, 195, SpaceX, SpaceY)
+	DaubtCard(1345, 195, SpaceX, SpaceY)
 	
 	; Second row
-	DaubtCard(785, 500, SpaceX, SpaceY)
-	DaubtCard(1065, 500, SpaceX, SpaceY)
-	DaubtCard(1345, 500, SpaceX, SpaceY)
+	DaubtCard(785, 510, SpaceX, SpaceY)
+	DaubtCard(1065, 510, SpaceX, SpaceY)
+	DaubtCard(1345, 510, SpaceX, SpaceY)
 	
 	; Third row
-	DaubtCard(785, 815, SpaceX, SpaceY)
-	DaubtCard(1065, 815, SpaceX, SpaceY)
-	DaubtCard(1345, 815, SpaceX, SpaceY)
+	DaubtCard(785, 825, SpaceX, SpaceY)
+	DaubtCard(1065, 825, SpaceX, SpaceY)
+	DaubtCard(1345, 825, SpaceX, SpaceY)
 
 	Return
 }
@@ -69,9 +70,13 @@ Daubt(TileX, TileY)
 	{
 		PixelGetColor, Color, %TileX%, %TileY%, RGB
 
-		Red := SubStr(Color, 3, 2), Blue := SubStr(Color, 7, 2)
+		Red := SubStr(Color, 3, 1), Green := SubStr(Color, 5, 1), Blue := SubStr(Color, 7, 1)
+		
+		IsRed := (Red == "C" and Green == "2" and Blue == "0")
+		IsGreen := (Red == "6" and Green == "C" and Blue == "2")
+		IsWhite := (Red == "F" and Green == "F" and Blue == "F")
 
-		If (!(Red == "CC" and Blue == "00") and !(Red == "FF" and Blue == "FF"))
+		If (!IsRed and !IsGreen and !IsWhite)
 		{
 			MouseClick, Left, %TileX%, %TileY%, 2, 0
 		}

--- a/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
+++ b/Win81 Without Ads/Bingo.Win81.1920x1080.WithoutAds.9-cards.ahk
@@ -6,6 +6,30 @@ UseColorCheck := true
 Escape:: ExitApp ; Escape to exit
 ^p::Pause ; Ctrl+P Pause
 
+; Ctrl+O to click on the power up button
+^o::
+{
+	MouseClick, Left, 1845, 300, 1, 0
+	Return
+}
+
+; Ctrl+D to click on the Bingo buttons
+^d::
+{
+	MouseClick, Left, 880, 420, 1, 0
+	MouseClick, Left, 1165, 420, 1, 0
+	MouseClick, Left, 1445, 420, 1, 0
+
+	MouseClick, Left, 880, 740, 1, 0
+	MouseClick, Left, 1165, 740, 1, 0
+	MouseClick, Left, 1445, 740, 1, 0
+
+	MouseClick, Left, 880, 1050, 1, 0
+	MouseClick, Left, 1165, 1050, 1, 0
+	MouseClick, Left, 1445, 1050, 1, 0
+	Return
+}
+
 ^b::      ; Ctrl+B AutoDaubt
 {
 	SpaceX := 50, SpaceY := 41
@@ -86,16 +110,3 @@ Daubt(TileX, TileY)
 		MouseClick, Left, %TileX%, %TileY%, 2, 0
 	}
 }
-
-^d::
-MouseClick, Left, 880, 420, 1, 0
-MouseClick, Left, 1165, 420, 1, 0
-MouseClick, Left, 1445, 420, 1, 0
-
-MouseClick, Left, 880, 740, 1, 0
-MouseClick, Left, 1165, 740, 1, 0
-MouseClick, Left, 1445, 740, 1, 0
-
-MouseClick, Left, 880, 1050, 1, 0
-MouseClick, Left, 1165, 1050, 1, 0
-MouseClick, Left, 1445, 1050, 1, 0


### PR DESCRIPTION
Add scripts for Windows 8.1 without Ads for 4, 6, 8, and 9 cards at 1920x1080 resolution.

- Added Esc to all WithoutAds scripts for closing the program.
- Added Ctrl+D to all WithoutAds scripts for clicking on all of the Bingo buttons.
- Added Ctrl+O to all WithoutAds scripts to click on the power up button.
- Improvements to ColorCheck to make it faster and to recognize Green/Bingo squares.